### PR TITLE
Updates links to iTunes and Google Play.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ Functional Programming In Games
 
 #### Shipped or in development commercial games made with FP languages
 * [Onikira: Demon Killer](http://www.digitalfurnacegames.com/) is a 2D side scrolling beat ‘em up set in a fantasy feudal Japan. It's on Steam Early Access, written in F#.
-* [Wayward Tide](http://blog.chucklefish.org/set-sail-for-wayward-tide/) A game in development, targeting pc and written in Haskell.
-* [Magic Cookies](http://keera.co.uk/blog/2015/03/19/magic-cookies-released-google-play/) Published on Android's [Play Store](https://play.google.com/store/apps/details?id=uk.co.keera.games.magiccookies), it's written in Haskell 
+* [Wayward Tide](http://blog.chucklefish.org/set-sail-for-wayward-tide/) A game in development, targeting pc and written in Haskell
+* [Magic Cookies](http://keera.co.uk/blog/2015/03/19/magic-cookies-released-google-play/) Published on [iTunes](https://itunes.apple.com/us/app/magic-cookies/id1244709871) and [Google Play for Android](https://play.google.com/store/apps/details?id=uk.co.keera.games.magiccookies), it's written in Haskell.
 * [Nikki and the Robots](https://github.com/nikki-and-the-robots/nikki) is a 2-dimensional platform game written in Haskell, now open source. It's published on Steam.
 * [Asteroid Sharpshooter](http://marketplace.xbox.com/en-US/Product/Asteroid-Sharpshooter/66acd000-77fe-1000-9115-d80258550797) published on Xbox Live Indie Games, written in F#. [Slides on the development process](https://docs.google.com/presentation/d/1teGhBf-m7qRkMzsbCKvRcIEo-QLwdK9w8VOEWqu1qWQ/edit#slide=id.p). His [blog](http://sharp-gamedev.blogspot.co.uk/2011/03/asteroid-sharpshooter-post-mortem.html) has more information on how he made [F# work with XNA on Xbox 360](http://sharp-gamedev.blogspot.co.uk/search/label/xna).
 
 #### Open Source Games
-* [Haskanoid](https://github.com/ivanperez-keera/haskanoid) A breakout game in Haskell using SDL and FRP, with Wiimote and Kinect support.
+* [Haskanoid](https://github.com/ivanperez-keera/haskanoid) A breakout game in Haskell using SDL and FRP, with Wiimote and Kinect support. [Available on Google Play](https://play.google.com/store/apps/details?id=uk.co.keera.games.breakout.beta).
 * [Allure of the Stars](https://github.com/AllureOfTheStars/Allure) is a near-future Sci-Fi roguelike and tactical squad game written in Haskell. 
 * [Nikki and the Robots](https://github.com/nikki-and-the-robots/nikki) commercial game written in Haskell, now open source.
 


### PR DESCRIPTION
The links to mobile haskell games did not include the iOS version of Magic Cookies or the Android version of Haskanoid. This commit adds those links.